### PR TITLE
Add PostgreSQL 16/17 support by add pg_uuid_t type cast

### DIFF
--- a/acl_uuid.c
+++ b/acl_uuid.c
@@ -163,13 +163,13 @@ static void
 format_who(StringInfo out, intptr_t opaque)
 {
 	appendStringInfoString(out, DatumGetCString(DirectFunctionCall1(
-										uuid_out, UUIDPGetDatum(opaque))));
+										uuid_out, UUIDPGetDatum((const pg_uuid_t *) opaque))));
 }
 
 static AclEntryBase *
 extract_acl_entry_base(void *entry)
 {
-	return &((AclEntryUUID *) entry)->base;
+	return &((AclEntryUUID *UUIDPGetDatum) entry)->base;
 }
 
 static bool


### PR DESCRIPTION
Otherwise got compile error against PostgreSQL 16/17

```
$ rpmbuild --with debuginfo --define "pgmajorversion 16" -ba ~/rpmbuild/SPECS/acl.spec
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.nLdAkk
+ umask 022
+ cd /home/vagrant/rpmbuild/BUILD
+ cd /home/vagrant/rpmbuild/BUILD
+ rm -rf acl-1.0.4
+ /usr/bin/gzip -dc /home/vagrant/rpmbuild/SOURCES/acl-1.0.4.tar.gz
+ /usr/bin/tar -xof -
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd acl-1.0.4
+ /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+ exit 0
Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.7j37p0
+ umask 022
+ cd /home/vagrant/rpmbuild/BUILD
+ cd acl-1.0.4
+ PATH=/usr/pgsql-16/bin:/usr/pgsql-17/bin:/home/vagrant/.cargo/bin:/usr/lib64/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+ /usr/bin/make -j10
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fPIC -fvisibility=hidden -Wall -I. -I./ -I/usr/pgsql-16/include/server -I/usr/pgsql-16/include/internal  -D_GNU_SOURCE -I/usr/include/libxml2  -I/usr/include  -c -o acl.o acl.c
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fPIC -fvisibility=hidden -Wall -I. -I./ -I/usr/pgsql-16/include/server -I/usr/pgsql-16/include/internal  -D_GNU_SOURCE -I/usr/include/libxml2  -I/usr/include  -c -o acl_oid.o acl_oid.c
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fPIC -fvisibility=hidden -Wall -I. -I./ -I/usr/pgsql-16/include/server -I/usr/pgsql-16/include/internal  -D_GNU_SOURCE -I/usr/include/libxml2  -I/usr/include  -c -o acl_uuid.o acl_uuid.c
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fPIC -fvisibility=hidden -Wall -I. -I./ -I/usr/pgsql-16/include/server -I/usr/pgsql-16/include/internal  -D_GNU_SOURCE -I/usr/include/libxml2  -I/usr/include  -c -o acl_int8.o acl_int8.c
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fPIC -fvisibility=hidden -Wall -I. -I./ -I/usr/pgsql-16/include/server -I/usr/pgsql-16/include/internal  -D_GNU_SOURCE -I/usr/include/libxml2  -I/usr/include  -c -o acl_int4.o acl_int4.c
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fPIC -fvisibility=hidden -Wall -I. -I./ -I/usr/pgsql-16/include/server -I/usr/pgsql-16/include/internal  -D_GNU_SOURCE -I/usr/include/libxml2  -I/usr/include  -c -o util.o util.c
/usr/bin/clang -Wno-ignored-attributes -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -O2  -Wall -I. -I./ -I/usr/pgsql-16/include/server -I/usr/pgsql-16/include/internal  -D_GNU_SOURCE -I/usr/include/libxml2  -I/usr/include -flto=thin -emit-llvm -c -o acl.bc acl.c
/usr/bin/clang -Wno-ignored-attributes -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -O2  -Wall -I. -I./ -I/usr/pgsql-16/include/server -I/usr/pgsql-16/include/internal  -D_GNU_SOURCE -I/usr/include/libxml2  -I/usr/include -flto=thin -emit-llvm -c -o acl_oid.bc acl_oid.c
/usr/bin/clang -Wno-ignored-attributes -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -O2  -Wall -I. -I./ -I/usr/pgsql-16/include/server -I/usr/pgsql-16/include/internal  -D_GNU_SOURCE -I/usr/include/libxml2  -I/usr/include -flto=thin -emit-llvm -c -o acl_uuid.bc acl_uuid.c
/usr/bin/clang -Wno-ignored-attributes -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -O2  -Wall -I. -I./ -I/usr/pgsql-16/include/server -I/usr/pgsql-16/include/internal  -D_GNU_SOURCE -I/usr/include/libxml2  -I/usr/include -flto=thin -emit-llvm -c -o acl_int8.bc acl_int8.c
/usr/bin/clang -Wno-ignored-attributes -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -O2  -Wall -I. -I./ -I/usr/pgsql-16/include/server -I/usr/pgsql-16/include/internal  -D_GNU_SOURCE -I/usr/include/libxml2  -I/usr/include -flto=thin -emit-llvm -c -o acl_int4.bc acl_int4.c
In file included from acl_uuid.c:10:
acl_uuid.c: In function ‘format_who’:
acl_uuid.c:166:35: warning: passing argument 1 of ‘UUIDPGetDatum’ makes pointer from integer without a cast [-Wint-conversion]
           uuid_out, UUIDPGetDatum(opaque))));
                                   ^~~~~~
/usr/pgsql-16/include/server/fmgr.h:643:44: note: in definition of macro ‘DirectFunctionCall1’
  DirectFunctionCall1Coll(func, InvalidOid, arg1)
                                            ^~~~
In file included from acl_uuid.c:13:
/usr/pgsql-16/include/server/utils/uuid.h:27:32: note: expected ‘const pg_uuid_t *’ {aka ‘const struct pg_uuid_t *’} but argument is of type ‘intptr_t’ {aka ‘long int’}
 UUIDPGetDatum(const pg_uuid_t *X)
               ~~~~~~~~~~~~~~~~~^
/usr/bin/clang -Wno-ignored-attributes -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -O2  -Wall -I. -I./ -I/usr/pgsql-16/include/server -I/usr/pgsql-16/include/internal  -D_GNU_SOURCE -I/usr/include/libxml2  -I/usr/include -flto=thin -emit-llvm -c -o util.bc util.c
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fPIC -fvisibility=hidden -shared -o acl.so acl.o acl_oid.o acl_uuid.o acl_int8.o acl_int4.o util.o -L/usr/pgsql-16/lib  -Wl,--as-needed -L/usr/lib64 -L/usr/lib  -L/usr/lib64 -Wl,--as-needed -Wl,-rpath,'/usr/pgsql-16/lib',--enable-new-dtags  -fvisibility=hidden
acl_uuid.c:166:35: error: incompatible integer to pointer conversion passing 'intptr_t' (aka 'long') to parameter of type 'const pg_uuid_t *' (aka 'const struct pg_uuid_t *') [-Wint-conversion]
  166 |                                                                                 uuid_out, UUIDPGetDatum(opaque))));
      |                                                                                                         ^~~~~~
/usr/pgsql-16/include/server/fmgr.h:643:44: note: expanded from macro 'DirectFunctionCall1'
  643 |         DirectFunctionCall1Coll(func, InvalidOid, arg1)
      |                                                   ^~~~
/usr/pgsql-16/include/server/utils/uuid.h:27:32: note: passing argument to parameter 'X' here
   27 | UUIDPGetDatum(const pg_uuid_t *X)
      |                                ^
1 error generated.
make: *** [/usr/pgsql-16/lib/pgxs/src/makefiles/../../src/Makefile.global:1093: acl_uuid.bc] Error 1
make: *** Waiting for unfinished jobs....
error: Bad exit status from /var/tmp/rpm-tmp.7j37p0 (%build)


RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.7j37p0 (%build)
```